### PR TITLE
Burger menu: Respect push button padding in style sheet.

### DIFF
--- a/src/burgermenu.cpp
+++ b/src/burgermenu.cpp
@@ -42,16 +42,17 @@ public:
         opt.state |= (mAction->isChecked() ? QStyle::State_On : QStyle::State_Off);
 
         style()->drawPrimitive(QStyle::PE_Widget, &opt, &painter, this);
+        const QRect contentsRect = style()->subElementRect(QStyle::SE_PushButtonContents, &opt, this);
         if(!mAction->icon().isNull())
         {
             QIcon::Mode mode = ((opt.state & QStyle::State_MouseOver) == 0) ? QIcon::Normal : QIcon::Active;
             if(!isEnabled())
                 mode = QIcon::Disabled;
             QIcon::State state = mAction->isChecked() ? QIcon::On : QIcon::Off;
-            painter.drawPixmap(QRect(QPoint(0,0), mIconSize), mAction->icon().pixmap(mIconSize, mode, state));
+            painter.drawPixmap(QRect(contentsRect.topLeft(), mIconSize), mAction->icon().pixmap(mIconSize, mode, state));
         }
 
-        opt.rect = rect().adjusted(mIconSize.width(), 0, 0, 0);
+        opt.rect = contentsRect.adjusted(mIconSize.width()+1, 0, 0, 0);
         opt.text = fontMetrics().elidedText(mAction->iconText(), Qt::ElideRight, opt.rect.width(), Qt::TextShowMnemonic);
         style()->drawControl(QStyle::CE_CheckBoxLabel, &opt, &painter, this);
     }
@@ -171,9 +172,9 @@ void BurgerMenu::setIconSize(const QSize& size)
         btn->setIconSize(size);
 
     if(mBurgerButton->isChecked())
-        setFixedWidth(size.width() + mMenuWidth);
+        setFixedWidth(mBurgerButton->width() + mMenuWidth);
     else
-        setFixedWidth(size.width());
+        setFixedWidth(mBurgerButton->width());
 
     emit iconSizeChanged(size);
 }
@@ -186,9 +187,9 @@ void BurgerMenu::setMenuWidth(int width)
     mMenuWidth = width;
 
     if(mBurgerButton->isChecked())
-        setFixedWidth(mBurgerButton->iconSize().width() + mMenuWidth);
+        setFixedWidth(mBurgerButton->width() + mMenuWidth);
     else
-        setFixedWidth(mBurgerButton->iconSize().width());
+        setFixedWidth(mBurgerButton->width());
 
     emit menuWidthChanged(mMenuWidth);
 }
@@ -199,8 +200,8 @@ void BurgerMenu::setExpansionState(bool expanded)
     {
         auto anim = new QPropertyAnimation(this, "minimumWidth", this);
         anim->setDuration(250);
-        anim->setStartValue(mBurgerButton->iconSize().width());
-        anim->setEndValue(mBurgerButton->iconSize().width() + mMenuWidth);
+        anim->setStartValue(mBurgerButton->width());
+        anim->setEndValue(mBurgerButton->width() + mMenuWidth);
         anim->setDirection(expanded ? QAbstractAnimation::Forward : QAbstractAnimation::Backward);
         anim->setEasingCurve(expanded ? QEasingCurve::OutCubic : QEasingCurve::InCubic);
         anim->start(QAbstractAnimation::DeleteWhenStopped);
@@ -208,9 +209,9 @@ void BurgerMenu::setExpansionState(bool expanded)
     else
     {
         if(expanded)
-            setFixedWidth(mBurgerButton->iconSize().width() + mMenuWidth);
+            setFixedWidth(mBurgerButton->width() + mMenuWidth);
         else
-            setFixedWidth(mBurgerButton->iconSize().width());
+            setFixedWidth(mBurgerButton->width());
     }
 }
 


### PR DESCRIPTION
Make sure the width of the menu bar includes the padding as well without clipping off part of the icon.
Because a fixed width is used, it should be safe to just use the
 width() of the button.
Example of a styled menu with vertically centered icons and text:
![styled-burger-menu](https://user-images.githubusercontent.com/39145/77327505-b8b4db80-6cf1-11ea-9279-6a9056e44850.png)
